### PR TITLE
refactor/Cambiar formato de data que se envía con lista de países

### DIFF
--- a/api/src/miscellanea/CountiesArrays.ts
+++ b/api/src/miscellanea/CountiesArrays.ts
@@ -1,4 +1,4 @@
-export const countryListEN = [
+const countryListEN = [
   "Afghanistan",
   "Albania",
   "Algeria",
@@ -250,7 +250,7 @@ export const countryListEN = [
   "Åland Islands",
 ];
 
-export const countryListENAlpha2 = {
+const countryListENAlpha2 = {
   AF: "Afghanistan",
   AL: "Albania",
   DZ: "Algeria",
@@ -754,7 +754,10 @@ export const countryListESAlpha2 = {
   AX: "Islas Åland",
 };
 
-export const arrayOfCountriesTwoChars = [
+export const arrayOfArraysKeyValuesES = Object.entries(countryListESAlpha2);
+export const arrayOfArraysKeyValuesEN = Object.entries(countryListENAlpha2);
+
+const arrayOfCountriesTwoChars = [
   "AD",
   "AE",
   "AF",

--- a/api/src/routes/countries/countries-routes.ts
+++ b/api/src/routes/countries/countries-routes.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import {
-  countryListESAlpha2,
-  countryListENAlpha2,
+  arrayOfArraysKeyValuesEN,
+  arrayOfArraysKeyValuesES,
 } from "../../miscellanea/CountiesArrays";
 const router = Router();
 
@@ -10,10 +10,10 @@ router.get("/", (req: Request, res: Response) => {
   try {
     let lang = req.query.lang;
     if (lang === "en") {
-      return res.status(200).send(countryListENAlpha2);
+      return res.status(200).send(arrayOfArraysKeyValuesEN);
     }
     if (lang === "es") {
-      return res.status(200).send(countryListESAlpha2);
+      return res.status(200).send(arrayOfArraysKeyValuesES);
     }
   } catch (error: any) {
     console.log(`Error en "/countries". ${error.message}`);


### PR DESCRIPTION
Back-end:
- Cambiar la data que se envía con la lista de países. En vez de enviar un objeto con key-values, ahora se envía un arreglo de arreglos tipo ["AR", "Argentina"]