### PR TITLE
Despachar Post + agregar additional_contact_info + schemas: hacer number_on_doc opcional

### DIFF
--- a/api/build/src/mongoDB/models/Post.js
+++ b/api/build/src/mongoDB/models/Post.js
@@ -12,7 +12,7 @@ exports.postSchema = new mongoose_1.Schema({
     number_on_doc: {
         type: String,
         maxlength: 100,
-        required: true,
+        required: false,
         lowercase: true,
     },
     country_found: { type: String, required: true, uppercase: true },

--- a/api/build/src/mongoDB/models/Subscription.js
+++ b/api/build/src/mongoDB/models/Subscription.js
@@ -16,7 +16,7 @@ exports.subscriptionSchema = new mongoose_1.Schema({
     number_on_doc: {
         type: String,
         maxlength: 100,
-        required: true,
+        required: false,
         lowercase: true,
     },
     country_lost: { type: String, required: true, uppercase: true },

--- a/api/build/src/routes/post/post-middlewares.js
+++ b/api/build/src/routes/post/post-middlewares.js
@@ -41,7 +41,7 @@ function handleNewPostRequest(req, res) {
             const newPost = yield mongoDB_1.Post.create(validatedPost);
             userInDB.posts.push(newPost);
             yield userInDB.save();
-            res.status(200).send(newPost);
+            res.status(201).send(newPost);
             // CHEQUEO DE SUBSCRIPTIONS CON EL NEW POST:
             let resultOfSendingAlerts = yield (0, nodemailer_1.handleAlertAfterNewPost)(newPost);
             console.log(resultOfSendingAlerts);

--- a/api/build/src/routes/subscription/subscription-middlewares.js
+++ b/api/build/src/routes/subscription/subscription-middlewares.js
@@ -35,7 +35,7 @@ function handleCreateNewSubscriptionRequest(req, res) {
                 throw new Error(`El user id '${user_id}' es inválido.`);
             }
             const objToReturn = yield (0, subscription_r_auxiliary_1.handleNewSubscription)(req.body, user_id);
-            return res.status(200).send(objToReturn);
+            return res.status(201).send(objToReturn);
         }
         catch (error) {
             console.log(`Error en POST 'subscription/'. ${error.message}`);

--- a/api/build/src/validators/post-validators.js
+++ b/api/build/src/validators/post-validators.js
@@ -55,6 +55,9 @@ function checkNameOnDoc(nameFromReq) {
 }
 exports.checkNameOnDoc = checkNameOnDoc;
 function checkNumberOnDoc(numberOnDocFromReq) {
+    if (!numberOnDocFromReq) {
+        return undefined;
+    }
     if ((0, genericValidators_1.isStringBetween1AndXCharsLong)(100, numberOnDocFromReq)) {
         // estos métodos dejan afuera las letras con tíldes. Pero como debería ser un número, no deberían haber caracteres de ese tipo.
         let onlyAlphaNumCharsAndLowerCased = numberOnDocFromReq

--- a/api/src/mongoDB/models/Post.ts
+++ b/api/src/mongoDB/models/Post.ts
@@ -3,7 +3,7 @@ import { Date, Schema } from "mongoose";
 export interface IPost {
   _id?: string;
   name_on_doc: string;
-  number_on_doc: string;
+  number_on_doc?: string;
   country_found: string;
   date_found: Date;
   blurred_imgs: string[];
@@ -30,7 +30,7 @@ export const postSchema: Schema = new Schema<IPost>(
     number_on_doc: {
       type: String,
       maxlength: 100,
-      required: true,
+      required: false,
       lowercase: true,
     },
     country_found: { type: String, required: true, uppercase: true },

--- a/api/src/mongoDB/models/Subscription.ts
+++ b/api/src/mongoDB/models/Subscription.ts
@@ -8,7 +8,7 @@ import { Schema } from "mongoose";
 
 export interface ISubscription {
   name_on_doc: string;
-  number_on_doc: string;
+  number_on_doc?: string;
   country_lost: string;
   date_lost: Date;
   user_subscribed: { _id: string; name: string; email: string };
@@ -24,7 +24,7 @@ export const subscriptionSchema: Schema = new Schema<ISubscription>({
   number_on_doc: {
     type: String,
     maxlength: 100,
-    required: true,
+    required: false,
     lowercase: true,
   },
   country_lost: { type: String, required: true, uppercase: true },

--- a/api/src/routes/post/post-middlewares.ts
+++ b/api/src/routes/post/post-middlewares.ts
@@ -40,7 +40,7 @@ export async function handleNewPostRequest(req: JWTRequest, res: Response) {
     const newPost = await Post.create(validatedPost);
     userInDB.posts.push(newPost);
     await userInDB.save();
-    res.status(200).send(newPost);
+    res.status(201).send(newPost);
     // CHEQUEO DE SUBSCRIPTIONS CON EL NEW POST:
     let resultOfSendingAlerts = await handleAlertAfterNewPost(newPost);
     console.log(resultOfSendingAlerts);

--- a/api/src/routes/subscription/subscription-middlewares.ts
+++ b/api/src/routes/subscription/subscription-middlewares.ts
@@ -32,7 +32,7 @@ export async function handleCreateNewSubscriptionRequest(
       throw new Error(`El user id '${user_id}' es inválido.`);
     }
     const objToReturn = await handleNewSubscription(req.body, user_id);
-    return res.status(200).send(objToReturn);
+    return res.status(201).send(objToReturn);
   } catch (error: any) {
     console.log(`Error en POST 'subscription/'. ${error.message}`);
     return res.status(400).send({ error: error.message });

--- a/api/src/validators/post-validators.ts
+++ b/api/src/validators/post-validators.ts
@@ -12,7 +12,7 @@ import { IUserPosting } from "../mongoDB/models/Post";
 // VALIDATE UPDATE POST DATA :
 export function validateUpdatePostData(bodyFromReq: any): {
   name_on_doc: string;
-  number_on_doc: string;
+  number_on_doc: string | undefined;
   country_found: string;
   date_found: any;
   blurred_imgs: string[];
@@ -46,7 +46,7 @@ export function validateUpdatePostData(bodyFromReq: any): {
 // VALIDATE NEW POST :
 export function validatePost(bodyFromReq: any): {
   name_on_doc: string;
-  number_on_doc: string;
+  number_on_doc: string | undefined;
   country_found: string;
   date_found: any;
   blurred_imgs: string[];
@@ -102,7 +102,10 @@ export function checkNameOnDoc(nameFromReq: any): string {
   throw new Error(`El nombre en el documento "${nameFromReq} no es válido.`);
 }
 
-export function checkNumberOnDoc(numberOnDocFromReq: any): string {
+export function checkNumberOnDoc(numberOnDocFromReq: any): string | undefined {
+  if (!numberOnDocFromReq) {
+    return undefined;
+  }
   if (isStringBetween1AndXCharsLong(100, numberOnDocFromReq)) {
     // estos métodos dejan afuera las letras con tíldes. Pero como debería ser un número, no deberían haber caracteres de ese tipo.
     let onlyAlphaNumCharsAndLowerCased = numberOnDocFromReq

--- a/client/src/components/PostForm/PostForm.jsx
+++ b/client/src/components/PostForm/PostForm.jsx
@@ -7,6 +7,9 @@ import { postFormValidator } from "../../helpers/post-form-validator";
 import { validAttr } from "../../helpers/validAttributesObj";
 import { parseDateToSetMaxDate } from "../../helpers/dateParsers";
 import { useAuth0 } from "@auth0/auth0-react";
+import axios from "axios";
+import { URL_P_PO_NEW_POST } from "../../constants/url";
+import { header } from "../../constants/header";
 
 const PostForm = () => {
   const countries = useSelector((state) => state.user.countries);
@@ -46,6 +49,7 @@ const PostForm = () => {
     date_found: "",
     blurred_imgs: "",
     comments: "",
+    additional_contact_info: "",
   });
 
   const maxDateAllowed = parseDateToSetMaxDate();
@@ -64,12 +68,31 @@ const PostForm = () => {
     const validation = postFormValidator(post, t);
     if (validation.error) {
       console.log(`Error en la validación: ${validation.error}`);
+      alert(validation.error);
       errorMessage = validation.error;
     }
     if (validation === true) {
       const accessToken = await getAccessTokenSilently();
       console.log("Despachando createPost !", post);
-      // dispatch(createPost(post, accessToken));
+      try {
+        const response = await axios.post(
+          URL_P_PO_NEW_POST,
+          post,
+          header(accessToken)
+        );
+        if (response.status === 201) {
+          alert("Publicación creada exitosamente");
+          console.log(response);
+        }
+        if (response.status >= 400) {
+          alert("Algo salió mal. " + response.data?.error);
+          console.log(response);
+        }
+      } catch (error) {
+        alert("Hubo un error. " + error.message);
+        console.log(error);
+        // dispatch(createPost(post, accessToken));
+      }
     }
   };
 
@@ -201,7 +224,6 @@ const PostForm = () => {
             id="grid-zip"
             type="file"
             accept=".png, .jpg, .jpeg"
-            required
             multiple
             name="blurred_images"
             onChange={upload}
@@ -223,6 +245,27 @@ const PostForm = () => {
             maxLength={validAttr.comments.maxLength}
             className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 text-sm"
           ></textarea>
+        </div>
+        <div className="w-full md:w-1/2 px-3 mt-4">
+          <label
+            className=" tracking-wide text-gray-700 text-xs font-bold mb-2 grid"
+            htmlFor="grid-last-name"
+          >
+            {t("postForm.additional_contact_info_label")}
+            <span className="font-light">
+              ({t("postForm.additional_contacto_info_sub")})
+            </span>
+          </label>
+          <textarea
+            className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+            id="grid-last-name"
+            name="additional_contact_info"
+            value={post.additional_contact_info}
+            maxLength={validAttr.additional_contact_info.maxLength}
+            type="text"
+            placeholder={t("postForm.additional_contact_info_placeholder")}
+            onChange={handleChange}
+          />
         </div>
         <div className="w-full md:w-1/2 px-3 mt-2">
           <button className="w-full bg-gray-200 hover:bg-emerald-300 hover:text-white border border-emerald-300 rounded py-3 text-slate-500">

--- a/client/src/helpers/post-form-validator.js
+++ b/client/src/helpers/post-form-validator.js
@@ -7,8 +7,14 @@ import { validAttr } from "./validAttributesObj";
 
 export function postFormValidator(post, t) {
   try {
-    const { name_on_doc, number_on_doc, country_found, date_found, comments } =
-      post;
+    const {
+      name_on_doc,
+      number_on_doc,
+      country_found,
+      date_found,
+      comments,
+      additional_contact_info,
+    } = post;
     if (
       !isStringBetweenXAndYCharsLong(
         validAttr.name_on_doc.minLength,
@@ -47,6 +53,13 @@ export function postFormValidator(post, t) {
     }
     if (!isValidDateBoolean(date_found)) {
       throw new Error(t("postForm.errorDateInvalid"));
+    }
+    if (
+      additional_contact_info &&
+      additional_contact_info?.length >
+        validAttr.additional_contact_info.maxLength
+    ) {
+      throw new Error(t("postForm.errorAdditional_contact_info_length"));
     }
     return true;
   } catch (error) {

--- a/client/src/helpers/validAttributesObj.js
+++ b/client/src/helpers/validAttributesObj.js
@@ -13,6 +13,10 @@ export const validAttr = {
     maxLength: 800,
     minLength: 0,
   },
+  additional_contact_info: {
+    maxLength: 150,
+    minLength: 0,
+  },
   // USER PROFILE :
   email: {
     maxLength: 100,

--- a/client/src/i18next/en/postForm.js
+++ b/client/src/i18next/en/postForm.js
@@ -12,6 +12,11 @@ export const postForm = {
   title: "Found some documents?",
   commentsPlaceHolder: "Insert any relevant comments here",
   commentsLabel: "Comments",
+  additional_contact_info_label: "ADDITIONAL CONTACT INFORMATION",
+  additional_contacto_info_sub:
+    "We'll only show this information to the user that wants to contact you. This field is optional",
+  additional_contact_info_placeholder:
+    "Contact information (beside your email)",
   subtitle: "Complete the fields to create an announcement",
   submitButton: "Submit",
   // errors:
@@ -27,4 +32,6 @@ export const postForm = {
   errorDateFalsy: "You must enter a valid date.",
   errorCommentsLength:
     "The comments is too long. Maximum 800 characters allowed.",
+  errorAdditional_contact_info_length:
+    "The additional contact information data has too many characters.",
 };

--- a/client/src/i18next/esp/postForm.js
+++ b/client/src/i18next/esp/postForm.js
@@ -12,6 +12,11 @@ export const postForm = {
   title: "Encontraste documentos?",
   commentsLabel: "Comentarios",
   commentsPlaceHolder: "Comentarios relevantes",
+  additional_contact_info_label: "INFORMACIÓN DE CONTACTO ADICIONAL",
+  additional_contacto_info_sub:
+    "Sólo le mostraremos esta información al usuario que se quiera contactar contigo. Campo no obligatorio",
+  additional_contact_info_placeholder:
+    "Información de contacto adicional a su email",
   subtitle: "Completá el formulario para publicar un aviso",
   submitButton: "Crear aviso",
   //errors:
@@ -26,4 +31,6 @@ export const postForm = {
     "Por favor, ingrese la fecha en la que encontró el documento.",
   errorDateInvalid: "La fecha ingresada es inválida.",
   errorCommentsLength: "El comentario no puede tener más de 800 caracteres.",
+  errorAdditional_contact_info_length:
+    "La información de contacto adicional excede la cantidad de caracteres permitidos.",
 };


### PR DESCRIPTION
Back-end:
- Hacer prop number_on_doc opcional (undefined posible).
- Cambiar status code de creación de subscription y post, de 200 a 201.

Front-end:
- Agregar a postForm la prop additional_contact_info.
- Agregar validación para additional_contact_info en la fn validadora del postForm.
- Despachar el Post localmente en el componente y hacer manejo de errores provisorio con un alert().
